### PR TITLE
Loadbalancerclass support

### DIFF
--- a/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -64,6 +64,12 @@ Create cloud-config makro.
 {{ $key }} = {{ $value }}
 {{- end }}
 
+{{- range .Values.cloudConfig.loadBalancerClass.name }}
+[LoadBalancerClass "{{ .Values.cloudConfig.loadBalancerClass.name }}"]
+{{- range $key, $value := .Values.cloudConfig.loadBalancerClass.$name }}
+{{ $key }} = {{ $value }}
+{{- end }}
+
 [BlockStorage]
 {{- range $key, $value := .Values.cloudConfig.blockStorage }}
 {{ $key }} = {{ $value }}

--- a/charts/openstack-cloud-controller-manager/values.yaml
+++ b/charts/openstack-cloud-controller-manager/values.yaml
@@ -88,6 +88,7 @@ cloudConfig:
   global:
   networking:
   loadBalancer:
+  loadBalancerClass:
   blockStorage:
   metadata:
 


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
