### PR TITLE
gitpages

### DIFF
--- a/charts/openstack-cloud-controller-manager/index.yaml
+++ b/charts/openstack-cloud-controller-manager/index.yaml
@@ -8,15 +8,8 @@ entries:
     digest: 6fa7de1bf36d7965e6dd0d107607f9d7aad077c813850d888c22c2f1030409ce
     home: https://github.com/kubernetes/cloud-provider-openstack
     icon: https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/OpenStack-Logo-Vertical.png
-    maintainers:
-    - email: kubernetes@maurice-meyer.de
-      name: morremeyer
-      url: https://maurice-meyer.de
-    - email: f.kloeker@telekom.de
-      name: eumel8
-      url: https://www.telekom.com
     name: openstack-cloud-controller-manager
     urls:
-    - https://github.com/zakthan/cloud-provider-openstack/openstack-cloud-controller-manager-1.3.0.tgz
+    - https://github.com/zakthan/cloud-provider-openstack/raw/master/openstack-cloud-controller-manager-1.3.0.tgz
     version: 1.3.0
 generated: "2022-07-22T19:09:27.344488873+03:00"


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
